### PR TITLE
Fix a wrong comparison and saving a sorted set

### DIFF
--- a/sider/types.py
+++ b/sider/types.py
@@ -363,7 +363,7 @@ class SortedSet(Set):
                             repr(value))
         obj = sortedset.SortedSet(session, key, value_type=self.value_type)
         encode = self.value_type.encode
-        if session.server_version < (2, 4, 0):
+        if session.server_version_info < (2, 4, 0):
             if isinstance(value, collections.Mapping):
                 pairs = [
                     (encode(el), score)
@@ -391,7 +391,8 @@ class SortedSet(Set):
             args = tuple(args())
             def block(trial, transaction):
                 obj.clear()
-                session.client.zadd(key, *args)
+                if args:
+                    session.client.zadd(key, *args)
         session.transaction(block, [key], ignore_double=True)
         return obj
 

--- a/sidertests/test_session.py
+++ b/sidertests/test_session.py
@@ -62,3 +62,12 @@ def test_getset_list(session):
     assert list(lst) == ['a', 'b', 'c']
     with raises(TypeError):
         session.set(key('test_session_getset_list'), 1234, ListT)
+
+
+def test_version_info(session):
+    assert isinstance(session.server_version, str)
+    assert isinstance(session.server_version_info, tuple)
+    for v in session.server_version_info:
+        assert isinstance(v, int)
+    version_str = '.'.join(map(str, session.server_version_info))
+    assert session.server_version == version_str


### PR DESCRIPTION
``` py
if session.server_version < (2, 4, 0):
```

This comparison is always `True` because the type of `session.server_version` is `str`, so comparing it with a tuple would be affected by [this rule](http://docs.python.org/2.7/tutorial/datastructures.html#comparing-sequences-and-other-types).
