### PR TITLE
Add UUID type

### DIFF
--- a/sider/types.py
+++ b/sider/types.py
@@ -26,6 +26,7 @@ import collections
 import numbers
 import itertools
 import datetime
+import uuid
 from .lazyimport import list, set, sortedset
 from .datetime import UTC, FixedOffset
 
@@ -969,3 +970,24 @@ class TimeDelta(Bulk):
                                       microseconds=microseconds)
         raise ValueError('invalid bulk: ' + repr(bulk))
 
+
+class UUID(Bulk):
+    """Stores :class:`uuid.UUID` values.  For example:
+
+    .. sourcecode:: pycon
+
+       >>> import uuid
+       >>> u = UUID()
+       >>> u.encode(uuid.UUID(int=134626331218489933988508161913704617318))
+       '65481698-2f85-4bd6-8f7c-ee8aaecf1566'
+       >>> u.decode('65481698-2f85-4bd6-8f7c-ee8aaecf1566')
+       UUID('65481698-2f85-4bd6-8f7c-ee8aaecf1566')
+
+    """
+    def encode(self, value):
+        if not isinstance(value, uuid.UUID):
+            raise TypeError('expected an uuid.UUID, not ' + repr(value))
+        return str(value).encode('ascii')
+
+    def decode(self, bulk):
+        return uuid.UUID(bulk.decode('ascii'))

--- a/sidertests/test_types.py
+++ b/sidertests/test_types.py
@@ -1,8 +1,9 @@
 import datetime
+import uuid
 from pytest import raises
 from .env import key
 from .env import session
-from sider.types import Boolean, ByteString, Date, DateTime, TZDateTime
+from sider.types import Boolean, ByteString, Date, DateTime, TZDateTime, UUID
 from sider.datetime import FixedOffset
 
 
@@ -58,3 +59,18 @@ def test_tzdatetime(session):
     session.set(key('test_types_tzdatetime'), '1988-08-04', ByteString)
     with raises(ValueError):
         session.get(key('test_types_tzdatetime'), TZDateTime)
+
+
+def test_uuid(session):
+    uuid_v4 = uuid.UUID('ed386d46-fbe2-4cbc-98ab-72e90436b4a3')
+    session.set(key('test_types_uuid'), uuid_v4, UUID)
+    u = session.get(key('test_types_uuid'), UUID)
+    assert u == uuid_v4
+    assert u.version == 4
+    with raises(TypeError):
+        session.set(key('test_types_uuid'),
+                    22474335462895695114168873682703774849, UUID)
+    session.set(key('test_types_uuid'),
+                b'\x11\xea.X\x97bG\xf3\xa31\xf2\xfaY\x95\xb7m', ByteString)
+    with raises(ValueError):
+        session.get(key('test_types_uuid'), UUID)


### PR DESCRIPTION
I suggest to add a simple bulk type that stores [`uuid.UUID`](http://docs.python.org/2/library/uuid.html) values of the Python standard lib. For readability, the newly added type encodes UUID values into the human-readable format, rather than their byte representations.
