### PR TITLE
Fix missing incrementation in sider.list.List.__iter__()

### DIFF
--- a/sider/list.py
+++ b/sider/list.py
@@ -75,13 +75,12 @@ class List(collections.MutableSequence):
         step = 100  # FIXME: it is an arbitarary magic number.
         chunk = None
         decode = self.value_type.decode
-        mark = self.session.mark_query
+        self.session.mark_query([self.key])
         while chunk is None or len(chunk) >= step:
-            mark([self.key])
-            mark = lambda *_: _
-            chunk = self.session.client.lrange(self.key, i, i + step)
+            chunk = self.session.client.lrange(self.key, i, i + step - 1)
             for val in chunk:
                 yield decode(val)
+            i += step
 
     @query
     def __len__(self):

--- a/sidertests/test_list.py
+++ b/sidertests/test_list.py
@@ -354,6 +354,13 @@ def test_extend(session):
         listx.extend([object(), object()])
 
 
+def test_massive_extend(session):
+    huge_data = [chr(i) * 16 for i in range(ord('a'), ord('z') + 1)] * 100
+    list_ = session.get(key('test_list_massive_extend'), List)
+    list_.extend(huge_data)
+    assert huge_data == list(list_)
+
+
 def test_insert(session):
     list_ = session.set(key('test_list_insert'), ['b'], List)
     list_.insert(0, 'a')


### PR DESCRIPTION
This function have fetched a few items of the list that is too long to be fetched at once. Furthermore, this code used the trick to calling `Session.mark_query()` in the loop and prevent to calling it more than once. But it doesn't need to do because `mark_query()` was called exactly one time in the all situation. So I fixed it too.
