### PR TITLE
fix error during installation on python 3.x

### DIFF
--- a/sidertests/counter_recipe.py
+++ b/sidertests/counter_recipe.py
@@ -1,6 +1,8 @@
 """Counter class
 http://code.activestate.com/recipes/576611/
 """
+from __future__ import print_function
+
 from operator import itemgetter
 from heapq import nlargest
 from itertools import repeat, ifilter
@@ -191,4 +193,4 @@ class Counter(dict):
 
 if __name__ == '__main__':
     import doctest
-    print doctest.testmod()
+    print(doctest.testmod())


### PR DESCRIPTION
On python 3.4, it prints error message during `python setup.py install`

```
$ python setup.py install
running install
running bdist_egg
running egg_info
writing top-level names to Sider.egg-info/top_level.txt
writing requirements to Sider.egg-info/requires.txt
writing dependency_links to Sider.egg-info/dependency_links.txt
writing Sider.egg-info/PKG-INFO
reading manifest file 'Sider.egg-info/SOURCES.txt'
writing manifest file 'Sider.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
copying sidertests/counter_recipe.py -> build/lib/sidertests
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_sortedset.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_types.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/counter_recipe.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/__init__.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_session.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_list.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_transaction.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_utils.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/env.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_threadlocal.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_hash.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_sider.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sidertests/test_set.py -> build/bdist.linux-x86_64/egg/sidertests
copying build/lib/sider__exttest.py -> build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/warnings.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/exceptions.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/list.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/utils.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/set.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/lazyimport.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/types.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/hash.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/transaction.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/datetime.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/__init__.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/sortedset.py -> build/bdist.linux-x86_64/egg/sider
creating build/bdist.linux-x86_64/egg/sider/ext
copying build/lib/sider/ext/__init__.py -> build/bdist.linux-x86_64/egg/sider/ext
copying build/lib/sider/session.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/threadlocal.py -> build/bdist.linux-x86_64/egg/sider
copying build/lib/sider/version.py -> build/bdist.linux-x86_64/egg/sider
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_sortedset.py to test_sortedset.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_types.py to test_types.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/counter_recipe.py to counter_recipe.cpython-34.pyc
  File "build/bdist.linux-x86_64/egg/sidertests/counter_recipe.py", line 194
    print doctest.testmod()
                ^
SyntaxError: invalid syntax

byte-compiling build/bdist.linux-x86_64/egg/sidertests/__init__.py to __init__.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_session.py to test_session.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_list.py to test_list.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_transaction.py to test_transaction.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_utils.py to test_utils.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/env.py to env.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_threadlocal.py to test_threadlocal.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_hash.py to test_hash.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_sider.py to test_sider.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sidertests/test_set.py to test_set.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider__exttest.py to sider__exttest.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/warnings.py to warnings.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/exceptions.py to exceptions.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/list.py to list.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/utils.py to utils.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/set.py to set.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/lazyimport.py to lazyimport.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/types.py to types.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/hash.py to hash.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/transaction.py to transaction.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/datetime.py to datetime.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/__init__.py to __init__.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/sortedset.py to sortedset.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/ext/__init__.py to __init__.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/session.py to session.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/threadlocal.py to threadlocal.cpython-34.pyc
byte-compiling build/bdist.linux-x86_64/egg/sider/version.py to version.cpython-34.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying Sider.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying Sider.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying Sider.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying Sider.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying Sider.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating 'dist/Sider-0.3.0-py3.4.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing Sider-0.3.0-py3.4.egg
Removing /home/longfin/.venvs/sider/lib/python3.4/site-packages/Sider-0.3.0-py3.4.egg
Copying Sider-0.3.0-py3.4.egg to /home/longfin/.venvs/sider/lib/python3.4/site-packages
Sider 0.3.0 is already the active version in easy-install.pth

Installed /home/longfin/.venvs/sider/lib/python3.4/site-packages/Sider-0.3.0-py3.4.egg
Processing dependencies for Sider==0.3.0
Searching for redis==2.10.3
Best match: redis 2.10.3
Adding redis 2.10.3 to easy-install.pth file

Using /home/longfin/.venvs/sider/lib/python3.4/site-packages
Finished processing dependencies for Sider==0.3.0
```